### PR TITLE
Update return type on offsetGet()

### DIFF
--- a/src/Options/OptionsTrait.php
+++ b/src/Options/OptionsTrait.php
@@ -57,8 +57,7 @@ trait OptionsTrait
         return isset($this->$offset);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->$offset;
     }


### PR DESCRIPTION
As seen in deprecations logs messages 
`User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Google\ApiCore\Options\ClientOptions" now to avoid errors or add an explicit @return annotation to suppress this message.`

Same message with :
- `Google\ApiCore\Options\TransportOptions`
- `Google\ApiCore\Options\TransportOptions\GrpcFallbackTransportOptions`
-  `Google\ApiCore\Options\TransportOptions\RestTransportOptions`
- `Google\ApiCore\Options\CallOptions`
- .....

As seen in the php [documentation](https://www.php.net/manual/en/arrayaccess.offsetget.php) since php 8.0 ("_Can return all value types._ ")
`public ArrayAccess::offsetGet(mixed $offset): mixed`


